### PR TITLE
Update Chewie package source to use GitHub repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,17 @@
 {
     "require": {
-        "joetannenbaum/chewie": "^0.1.0",
+        "joetannenbaum/chewie": "dev-main",
         "laravel/prompts": "^0.1.15"
     },
     "autoload": {
         "psr-4": {
             "App\\": "src/"
+        }
+    },
+    "repositories": {
+        "chewie": {
+            "type": "vcs",
+            "url": "https://github.com/joetannenbaum/chewie.git"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c2f65785019ed82757b3029947d5e2b",
+    "content-hash": "70abcffebb313b9f7750f8fca52edd13",
     "packages": [
         {
             "name": "illuminate/collections",
@@ -203,11 +203,17 @@
         },
         {
             "name": "joetannenbaum/chewie",
-            "version": "0.1.2",
-            "dist": {
-                "type": "path",
-                "url": "/Users/joetannenbaum/Dev/projects/chewie",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joetannenbaum/chewie.git",
                 "reference": "977ce825e93df31307c57ecc9562380d645b401b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joetannenbaum/chewie/zipball/977ce825e93df31307c57ecc9562380d645b401b",
+                "reference": "977ce825e93df31307c57ecc9562380d645b401b",
+                "shasum": ""
             },
             "require": {
                 "laravel/prompts": "^0.1.15"
@@ -216,6 +222,7 @@
                 "pestphp/pest": "^2.33",
                 "tightenco/duster": "^2.7"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -225,9 +232,11 @@
                     "src/helpers.php"
                 ]
             },
-            "transport-options": {
-                "relative": false
-            }
+            "support": {
+                "source": "https://github.com/joetannenbaum/chewie/tree/0.1.2",
+                "issues": "https://github.com/joetannenbaum/chewie/issues"
+            },
+            "time": "2024-04-21T12:09:46+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -973,10 +982,12 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "joetannenbaum/chewie": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
**Reason for the change:** This PR updates the source of the Chewie package to use the GitHub repository instead of the current source.  Errors occurred when trying to install.

**Benefits:** This allows the project to be setup and run using composer install.

**Changes made:** Modified the composer.json file to point to the GitHub repository for the Chewie package.